### PR TITLE
feat: show active allocations in ShowCommand output

### DIFF
--- a/src/main/java/org/example/Commands/Impl/ShowCommand.java
+++ b/src/main/java/org/example/Commands/Impl/ShowCommand.java
@@ -41,6 +41,22 @@ public class ShowCommand extends AbstractCommand {
         out.append("]\n");
         out.append(sepLine);
 
+        out.append("\n\nActive Allocations: ");
+        // get active allocations, then for each active show: [id=<id>] @<start> +<size>B (used=<size>B) separated by '|'
+        var activeAllocations = memory.getActiveAllocations();
+        if (activeAllocations.isEmpty()) {
+            out.append("None\n");
+        } else {
+            for (int i = 0; i < activeAllocations.size(); i++) {
+                var alloc = activeAllocations.get(i);
+                out.append("[id=").append(alloc.id()).append("] @").append(alloc.start()).append(" +").append(alloc.size()).append("B (used=").append(alloc.usedSize()).append("B)");
+                if (i < activeAllocations.size() - 1) {
+                    out.append(" | ");
+                }
+            }
+            out.append("\n");
+        }
+
         return CommandsResult.Success(out.toString());
     }
 

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -6,6 +6,8 @@ import org.example.Memory.AbstractMemoryManagement;
 import org.example.Memory.MemoryManagement;
 import org.example.Parser.CommandParser;
 import org.example.Parser.ICommandParser;
+import org.example.Parser.Validator.CommandValidator;
+import org.example.Parser.Validator.ICommandValidator;
 import org.example.shell.Shell;
 
 import java.util.Map;
@@ -17,7 +19,8 @@ public class Main {
 
         Scanner scanner = new Scanner(System.in);
         AbstractMemoryManagement memoryManagement = new MemoryManagement();
-        ICommandParser parser = new CommandParser();
+        ICommandValidator validator = new CommandValidator();
+        ICommandParser parser = new CommandParser(validator);
         var commands = CommandFactory.createCommands(memoryManagement);
 
         try (var shell = new Shell(scanner, parser, commands)) {

--- a/src/main/java/org/example/Memory/AllocationInfo.java
+++ b/src/main/java/org/example/Memory/AllocationInfo.java
@@ -1,0 +1,15 @@
+package org.example.Memory;
+
+import lombok.Getter;
+
+/**
+ * Record representing information about an active memory allocation.
+ *
+ * @param id       the unique identifier of the allocation
+ * @param start    the starting index of the allocation in memory
+ * @param size     the total size of the allocation in bytes
+ * @param usedSize the actual used size of the allocation in bytes (same as size for contiguous allocations)
+ */
+public record AllocationInfo(int id, int start, int size, int usedSize) {
+}
+

--- a/src/main/java/org/example/Parser/Validator/CommandValidator.java
+++ b/src/main/java/org/example/Parser/Validator/CommandValidator.java
@@ -12,7 +12,7 @@ public class CommandValidator implements ICommandValidator {
         return switch (command) {
             case INIT -> validateInit(args);
             case ALLOC -> validateAlloc(args);
-            case FREE_ID -> validateFreeId(args);
+            case FREEID -> validateFreeId(args);
             case SHOW, STATS, RESET, HELP, DO_NOTHING, EXIT -> validateNoArgs(args, command);
             case UNKNOWN -> ValidationResult.failure("Unknown command");
         };


### PR DESCRIPTION
Add active allocations display to ShowCommand, listing each allocation's id, start index, size, and used size. Implement getActiveAllocations in AbstractMemoryManagement and introduce AllocationInfo record for allocation metadata. Fix FREEID command validation and ensure allocation map is cleared on memory reset.